### PR TITLE
Update generic_package_scripts/nova_diablo_scripts/debian/nova_sudoers

### DIFF
--- a/generic_package_scripts/nova_diablo_scripts/debian/nova_sudoers
+++ b/generic_package_scripts/nova_diablo_scripts/debian/nova_sudoers
@@ -3,6 +3,7 @@ Cmnd_Alias NOVACMDS = /bin/chmod /var/lib/nova/tmp/*/root/.ssh, \
                       /bin/chown,                               \
                       /bin/chmod,                               \
                       /bin/dd,                                  \
+                      /bin/rm,                                  \
                       /sbin/ifconfig,                           \
                       /sbin/ip,                                 \
                       /sbin/route,                              \


### PR DESCRIPTION
nova needs access to rm to cleanup orphaned files.
